### PR TITLE
Skips authentication for the daycares show action

### DIFF
--- a/app/controllers/daycares_controller.rb
+++ b/app/controllers/daycares_controller.rb
@@ -1,5 +1,5 @@
 class DaycaresController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index]
+  skip_before_action :authenticate_user!, only: %i[index show]
   before_action :set_daycare, only: %i[show]
 
   def index


### PR DESCRIPTION
What has changed
- Daycares show action no longer requires authentication before showing the daycares

@Driftmaster7 