### PR TITLE
Adds acts-as-favoritor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,14 @@ gem 'pundit'
 # Geocoder
 gem 'geocoder'
 
-# PG search
+# PG Search
 gem 'pg_search', '~> 2.3.0'
 
-# image upload
+# Cloudinary
 gem 'cloudinary', '~> 1.16.0'
+
+# Acts as favoritor
+gem 'acts_as_favoritor'
 
 # Faker
 gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_favoritor (6.0.0)
+      activerecord (>= 5.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.5.0)
@@ -286,6 +288,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts_as_favoritor
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.4)
   byebug

--- a/app/models/daycare.rb
+++ b/app/models/daycare.rb
@@ -5,6 +5,7 @@ class Daycare < ApplicationRecord
   has_many :daycare_tags, dependent: :destroy
   has_many :tags, through: :daycare_tags
   has_one_attached :photo
+  acts_as_favoritable
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?
   include PgSearch::Model

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Favorite < ApplicationRecord
+  extend ActsAsFavoritor::FavoriteScopes
+
+  belongs_to :favoritable, polymorphic: true
+  belongs_to :favoritor, polymorphic: true
+
+  def block!
+    update!(blocked: true)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :reviews, foreign_key: :client_id,  dependent: :destroy
   has_many :consultations, foreign_key: :client_id, dependent: :destroy
   has_many :daycares, foreign_key: :supplier_id, dependent: :destroy
+  acts_as_favoritor
   enum category: {
     client: 1,
     supplier: 2

--- a/config/initializers/acts_as_favoritor.rb
+++ b/config/initializers/acts_as_favoritor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ActsAsFavoritor.configure do |config|
+  # Specify your default scope. Learn more about scopes here: https://github.com/jonhue/acts_as_favoritor#scopes
+  # config.default_scope = :favorite
+
+  # Enable caching. Learn more about caching here: https://github.com/jonhue/acts_as_favoritor#caching
+  # config.cache = false
+end

--- a/db/migrate/20220530182100_acts_as_favoritor_migration.rb
+++ b/db/migrate/20220530182100_acts_as_favoritor_migration.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ActsAsFavoritorMigration < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :favorites, force: true do |t|
+      t.references :favoritable, polymorphic: true, null: false
+      t.references :favoritor, polymorphic: true, null: false
+      t.string :scope, default: ActsAsFavoritor.configuration.default_scope,
+                       null: false,
+                       index: true
+      t.boolean :blocked, default: false, null: false, index: true
+      t.timestamps
+    end
+
+    add_index :favorites,
+              ['favoritor_id', 'favoritor_type'],
+              name: 'fk_favorites'
+    add_index :favorites,
+              ['favoritable_id', 'favoritable_type'],
+              name: 'fk_favoritables'
+    add_index :favorites,
+              ['favoritable_type', 'favoritable_id', 'favoritor_type',
+              'favoritor_id', 'scope'],
+              name: 'uniq_favorites__and_favoritables', unique: true
+  end
+
+  def self.down
+    drop_table :favorites
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_30_130429) do
+ActiveRecord::Schema.define(version: 2022_05_30_182100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,24 @@ ActiveRecord::Schema.define(version: 2022_05_30_130429) do
     t.float "latitude"
     t.float "longitude"
     t.index ["supplier_id"], name: "index_daycares_on_supplier_id"
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.string "favoritable_type", null: false
+    t.bigint "favoritable_id", null: false
+    t.string "favoritor_type", null: false
+    t.bigint "favoritor_id", null: false
+    t.string "scope", default: "favorite", null: false
+    t.boolean "blocked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["blocked"], name: "index_favorites_on_blocked"
+    t.index ["favoritable_id", "favoritable_type"], name: "fk_favoritables"
+    t.index ["favoritable_type", "favoritable_id", "favoritor_type", "favoritor_id", "scope"], name: "uniq_favorites__and_favoritables", unique: true
+    t.index ["favoritable_type", "favoritable_id"], name: "index_favorites_on_favoritable"
+    t.index ["favoritor_id", "favoritor_type"], name: "fk_favorites"
+    t.index ["favoritor_type", "favoritor_id"], name: "index_favorites_on_favoritor"
+    t.index ["scope"], name: "index_favorites_on_scope"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
What has changed 
- Adds acts-as-favoritor gem
- Modifies user and daycare models to allow users to like daycares / save them for later

For a description of the new methods available, see:
https://github.com/jonhue/acts_as_favoritor